### PR TITLE
fixed bug when taking the bus for the second time

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -239,6 +239,9 @@ RegisterNetEvent('qb-busjob:client:DoBusNpc', function()
                         until not inRange
                     end)
                 else
+                    route = 1
+                    NpcData.NpcTaken = false
+                    NpcData.Active = false
                     exports["qb-core"]:HideText()
                     inRange = false
                 end


### PR DESCRIPTION
When taking the bus and leaving it without finishing the route and you returned the bus when you took it out again, it did not assign you a route