### PR TITLE
Localised player data & made blips only show for job players

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -3,7 +3,7 @@ local QBCore = exports['qb-core']:GetCoreObject()
 local PlayerData = QBCore.Functions.GetPlayerData()
 local route = 1
 local max = #Config.NPCLocations.Locations
-local busBlip
+local busBlip = nil
 
 local NpcData = {
     Active = false,
@@ -39,17 +39,23 @@ local function resetNpcTask()
     }
 end
 
-local function createBlips()
-    busBlip = AddBlipForCoord(Config.Location)
-    SetBlipSprite (busBlip, 513)
-    SetBlipDisplay(busBlip, 4)
-    SetBlipScale  (busBlip, 0.6)
-    SetBlipAsShortRange(busBlip, true)
-    SetBlipColour(busBlip, 49)
-    BeginTextCommandSetBlipName("STRING")
-    AddTextComponentSubstringPlayerName(Lang:t('info.bus_depot'))
-    EndTextCommandSetBlipName(busBlip)
+local function updateBlip()
+    if PlayerData.job.name == "bus" then
+        busBlip = AddBlipForCoord(Config.Location)
+        SetBlipSprite (busBlip, 513)
+        SetBlipDisplay(busBlip, 4)
+        SetBlipScale  (busBlip, 0.6)
+        SetBlipAsShortRange(busBlip, true)
+        SetBlipColour(busBlip, 49)
+        BeginTextCommandSetBlipName("STRING")
+        AddTextComponentSubstringPlayerName(Lang:t('info.bus_depot'))
+        EndTextCommandSetBlipName(busBlip)
+    elseif busBlip ~= nil then
+        RemoveBlip(busBlip)
+    end
 end
+
+
 
 local function whitelistedVehicle()
     local ped = PlayerPedId()
@@ -187,18 +193,13 @@ end)
 AddEventHandler('onResourceStart', function(resourceName)
     -- handles script restarts
     if GetCurrentResourceName() == resourceName then
-        if PlayerData.job.name == "bus" then
-            createBlips()
-        end
+        updateBlip()
     end
   end)
 
 RegisterNetEvent('QBCore:Client:OnPlayerLoaded', function()
     PlayerData = QBCore.Functions.GetPlayerData()
-
-    if PlayerData.job.name == "bus" then
-        createBlips()
-    end
+    updateBlip()
 end)
 
 RegisterNetEvent('QBCore:Client:OnPlayerUnload', function()
@@ -207,12 +208,8 @@ end)
 
 RegisterNetEvent('QBCore:Client:OnJobUpdate', function(JobInfo)
     PlayerData.job = JobInfo
+    updateBlip()
 
-    if PlayerData.job.name == "bus" then
-        createBlips()
-    elseif busBlip then
-        RemoveBlip(busBlip)
-    end
 end)
 
 RegisterNetEvent('qb-busjob:client:DoBusNpc', function()

--- a/client/main.lua
+++ b/client/main.lua
@@ -39,15 +39,15 @@ local function resetNpcTask()
 end
 
 local function createBlips()
-    local BusBlip = AddBlipForCoord(Config.Location)
-    SetBlipSprite (BusBlip, 513)
-    SetBlipDisplay(BusBlip, 4)
-    SetBlipScale  (BusBlip, 0.6)
-    SetBlipAsShortRange(BusBlip, true)
-    SetBlipColour(BusBlip, 49)
+    local busBlip = AddBlipForCoord(Config.Location)
+    SetBlipSprite (busBlip, 513)
+    SetBlipDisplay(busBlip, 4)
+    SetBlipScale  (busBlip, 0.6)
+    SetBlipAsShortRange(busBlip, true)
+    SetBlipColour(busBlip, 49)
     BeginTextCommandSetBlipName("STRING")
     AddTextComponentSubstringPlayerName(Lang:t('info.bus_depot'))
-    EndTextCommandSetBlipName(BusBlip)
+    EndTextCommandSetBlipName(busBlip)
 end
 
 local function whitelistedVehicle()
@@ -213,8 +213,6 @@ RegisterNetEvent('QBCore:Client:OnJobUpdate', function(JobInfo)
 
     if PlayerData.job.name == "bus" then
         createBlips()
-    elseif BusBlip then
-        RemoveBlip(BusBlip)
     end
 end)
 

--- a/client/main.lua
+++ b/client/main.lua
@@ -3,6 +3,7 @@ local QBCore = exports['qb-core']:GetCoreObject()
 local PlayerData = QBCore.Functions.GetPlayerData()
 local route = 1
 local max = #Config.NPCLocations.Locations
+local busBlip
 
 local NpcData = {
     Active = false,
@@ -39,7 +40,7 @@ local function resetNpcTask()
 end
 
 local function createBlips()
-    local busBlip = AddBlipForCoord(Config.Location)
+    busBlip = AddBlipForCoord(Config.Location)
     SetBlipSprite (busBlip, 513)
     SetBlipDisplay(busBlip, 4)
     SetBlipScale  (busBlip, 0.6)
@@ -204,15 +205,13 @@ RegisterNetEvent('QBCore:Client:OnPlayerUnload', function()
     PlayerData = {}
 end)
 
-RegisterNetEvent('QBCore:Player:SetPlayerData', function(_PlayerData)
-    PlayerData = _PlayerData
-end)
-
 RegisterNetEvent('QBCore:Client:OnJobUpdate', function(JobInfo)
     PlayerData.job = JobInfo
 
     if PlayerData.job.name == "bus" then
         createBlips()
+    elseif busBlip then
+        RemoveBlip(busBlip)
     end
 end)
 


### PR DESCRIPTION
**Describe Pull request**
- 🎨 Localised player data
- 🎨 Added `createBlips()` local function and made blips only show for players with the bus job

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes] (Be honest)
- Does your code fit the style guidelines? [yes]
- Does your PR fit the contribution guidelines? [yes]
