### PR TITLE
[Bug fix] Added nextStop function - Fixes #49

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -75,13 +75,16 @@ local function whitelistedVehicle()
     return retval
 end
 
-local function GetDeliveryLocation()
+local function nextStop()
     if route <= (max - 1) then
         route = route + 1
     else
         route = 1
     end
+end
 
+local function GetDeliveryLocation()
+    nextStop()
     if NpcData.DeliveryBlip ~= nil then
         RemoveBlip(NpcData.DeliveryBlip)
     end
@@ -122,7 +125,7 @@ local function GetDeliveryLocation()
                         end
                         RemovePed(NpcData.Npc)
                         resetNpcTask()
-                        route = route + 1
+                        nextStop()
                         TriggerEvent('qb-busjob:client:DoBusNpc')
                         exports["qb-core"]:HideText()
                         PolyZone:destroy()


### PR DESCRIPTION
**Describe Pull request**
[Bug fix] Added nextStop function - Fixes #49
If the route ended on adrop off, it would just increment to the next value without checking if its reached the max number of stops. Added the check used to a local function and called that in the two required positions.

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes] (Be honest)
- Does your code fit the style guidelines? [yes]
- Does your PR fit the contribution guidelines? [yes]
