### PR TITLE
Update main.lua

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -61,7 +61,7 @@ local function whitelistedVehicle()
     local retval = false
 
     for i = 1, #Config.AllowedVehicles, 1 do
-        if veh == Config.AllowedVehicles[i].model then
+        if veh == joaat(Config.AllowedVehicles[i].model) then
             retval = true
         end
     end
@@ -71,7 +71,7 @@ local function whitelistedVehicle()
     end
 
     return retval
-end
+end 
 
 local function nextStop()
     if route <= (max - 1) then

--- a/client/main.lua
+++ b/client/main.lua
@@ -71,7 +71,7 @@ local function whitelistedVehicle()
     end
 
     return retval
-end 
+end
 
 local function nextStop()
     if route <= (max - 1) then


### PR DESCRIPTION
Change whitelisted vehicle pull function to correctly pull a string instead of a hash

This fixes the issue with the bus not being recognized as a whitelisted vehicle. 

Tested and confirmed to resolve that issue. 
